### PR TITLE
Fixes auto close closing all previous toasts

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -6,10 +6,11 @@ export const App = () => {
   const toastRef = useRef();
   const [text, setText] = useState('');
   const [mode, setMode] = useState('info');
-  const [autoClose, setAutoClose] = useState(false);
+  const [autoClose, setAutoClose] = useState({shouldAutoClose: false, toastId: null});
 
   const addToast = () => {
-    toastRef.current.addMessage({ mode, message: text });
+    const toastId = toastRef.current.addMessage({ mode, message: text });
+    return toastId;
   };
 
   return (
@@ -25,16 +26,19 @@ export const App = () => {
           onSubmit={e => {
             e.preventDefault();
             if (text) {
-              addToast();
+              const toastId = addToast();
               setText('');
+              if (autoClose.shouldAutoClose) {
+                setAutoClose( {shouldAutoClose: true, toastId: toastId} );
+              }
             }
           }}
         >
           <div className={styles.autoClose}>
             <input
               type="checkbox"
-              value={autoClose}
-              onChange={e => setAutoClose(e.target.checked)}
+              value={autoClose.shouldAutoClose}
+              onChange={e => setAutoClose({shouldAutoClose: e.target.checked, toastId: null})}
             />
             <label>Auto Close</label>
           </div>

--- a/src/components/ToastPortal/ToastPortal.js
+++ b/src/components/ToastPortal/ToastPortal.js
@@ -18,7 +18,7 @@ import { useState, forwardRef, useImperativeHandle } from 'react';
  */
 
 export const ToastPortal = forwardRef(
-  ({ autoClose = false, autoCloseTime = 5000 }, ref) => {
+  ({ autoClose = {}, autoCloseTime = 5000 }, ref) => {
     const [toasts, setToasts] = useState([]);
     const { loaded, portalId } = useToastPortal();
 
@@ -35,7 +35,9 @@ export const ToastPortal = forwardRef(
 
     useImperativeHandle(ref, () => ({
       addMessage(toast) {
-        setToasts([...toasts, { ...toast, id: uuid() }]);
+        const toastId = uuid();
+        setToasts([...toasts, { ...toast, id: toastId }]);
+        return toastId;
       },
     }));
 

--- a/src/hooks/useToastAutoClose.js
+++ b/src/hooks/useToastAutoClose.js
@@ -15,8 +15,8 @@ export const useToastAutoClose = ({
   }, [removing, setToasts]);
 
   useEffect(() => {
-    if (autoClose && toasts.length) {
-      const id = toasts[toasts.length - 1].id;
+    if (autoClose.shouldAutoClose && toasts.length) {
+      const id = autoClose.toastId;
       setTimeout(() => setRemoving(id), autoCloseTime);
     }
   }, [toasts, autoClose, autoCloseTime]);


### PR DESCRIPTION
after adding a few toasts without auto close, adding a new one with auto close checked will trigger auto
closing on all existing toasts.

this pr fixes the issue by passing the newly created toastId back from ToastPortal.js's addMessage()
function in to App.js's addToast(), which then is added to the autoClose state, now an object
consisting of { shouldAutoClose: boolean, toastId: id}

the toastId is then used in the useToastAutoClose.js's removing useEffect callback